### PR TITLE
Add `@table`

### DIFF
--- a/src/std.papyri
+++ b/src/std.papyri
@@ -81,6 +81,18 @@
     |<a class="footnote-ref"/><span class="footnote panel">$v</>
 }
 
+@fn tbl_row $row: inline list -> @match $row {
+    [$a] -> <td>$a</>,
+    [$a, *$tail] -> { <td>$a</> @tbl_row $tail }
+}
+
+@fn tbl_rows $rows: inline list list -> @match $rows {
+    [$a, *$tail] -> { <tr> @tbl_row $a </tr> @tbl_rows $tail },
+    [] -> {},
+}
+
+@export @fn table $tbl: inline list list -> { <table> @tbl_rows $tbl </> }
+
 @export(
     function=@dict::new(
         **$function,

--- a/src/std.papyri
+++ b/src/std.papyri
@@ -82,8 +82,8 @@
 }
 
 @fn tbl_row $row: inline list -> @match $row {
-    [$a] -> <td>$a</>,
-    [$a, *$tail] -> { <td>$a</> @tbl_row $tail }
+    [$a, *$tail] -> { <td>$a</> @tbl_row $tail },
+    [] -> {},
 }
 
 @fn tbl_rows $rows: inline list list -> @match $rows {


### PR DESCRIPTION
I needed a table function, so I made one for myself and decided to PR it to the stdlib. For some reason it really likes adding extra (empty) `<td>` elements at the start of each `<tr>` and idk why.